### PR TITLE
ci: Optimize CI workflow by replacing goreleaser snapshot build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
       - run: goreleaser check
-      - run: goreleaser release --snapshot --clean
+      - run: go build
 
   lint:
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,19 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - run: goreleaser check
       - run: go build
+
+  goreleaser:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - run: goreleaser check
 
   lint:
     timeout-minutes: 10


### PR DESCRIPTION
## Summary
- Replace `goreleaser release --snapshot --clean` with `go build` for significantly faster CI execution
- Separate `goreleaser check` into its own dedicated job for better organization

## Test plan
- [x] Verify CI workflow syntax is valid
- [x] Ensure all jobs maintain proper checkout and setup steps
- [x] Confirm build validation still occurs through `go build`
- [x] Validate goreleaser configuration checking is preserved

🤖 Generated with [Claude Code](https://claude.ai/code)