### PR TITLE
feat: add support for GitHub Container Registry (ghcr.io)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It can also be used as a docker cli plugin.
 - [Docker Hub](https://hub.docker.com/)
 - [Amazon ECR](https://aws.amazon.com/ecr/)
 - [Amazon ECR Public](https://docs.aws.amazon.com/AmazonECR/latest/public/index.html)
+- [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
 - [Google Artifact Registry](https://cloud.google.com/artifact-registry)
 
 # Installation

--- a/internal/registry/ghcr/registry.go
+++ b/internal/registry/ghcr/registry.go
@@ -1,0 +1,120 @@
+package ghcr
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+type Registry struct {
+	httpClient *http.Client
+}
+
+func New() *Registry {
+	return &Registry{
+		httpClient: new(http.Client),
+	}
+}
+
+type tokenResponse struct {
+	Token string `json:"token"`
+}
+
+type listTagsResponse struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+func (r *Registry) ListTags(name string) ([]string, error) {
+	tkn, err := r.auth(name)
+	if err != nil {
+		return nil, err
+	}
+
+	tags, err := r.listTags(name, tkn)
+	if err != nil {
+		return nil, err
+	}
+
+	return tags, nil
+}
+
+func (r *Registry) auth(name string) (string, error) {
+	u, err := url.ParseRequestURI("https://ghcr.io/token")
+	if err != nil {
+		return "", err
+	}
+
+	q := u.Query()
+	q.Set("scope", fmt.Sprintf("repository:%s:pull", name))
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		return "", errors.New(string(b))
+	}
+
+	var tokenResp tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return "", err
+	}
+
+	return tokenResp.Token, nil
+}
+
+func (r *Registry) listTags(name, tkn string) ([]string, error) {
+	u, err := url.ParseRequestURI("https://ghcr.io")
+	if err != nil {
+		return nil, err
+	}
+	u.Path = fmt.Sprintf("/v2/%s/tags/list", name)
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tkn))
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New(string(b))
+	}
+
+	var tagsResp listTagsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tagsResp); err != nil {
+		return nil, err
+	}
+
+	tags := tagsResp.Tags
+	for i, j := 0, len(tags)-1; i < j; i, j = i+1, j-1 {
+		tags[i], tags[j] = tags[j], tags[i]
+	}
+
+	return tags, nil
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -9,6 +9,7 @@ import (
 	"github.com/koki-develop/docker-tags/internal/registry/ecr"
 	"github.com/koki-develop/docker-tags/internal/registry/ecrpublic"
 	"github.com/koki-develop/docker-tags/internal/registry/gcr"
+	"github.com/koki-develop/docker-tags/internal/registry/ghcr"
 )
 
 type Registry interface {
@@ -30,6 +31,8 @@ func New(domain string, cfg *Config) (Registry, error) {
 		return ecr.New(&ecr.Config{Profile: cfg.AWSProfile, Domain: domain})
 	case domain == "gcr.io":
 		return gcr.New(), nil
+	case domain == "ghcr.io":
+		return ghcr.New(), nil
 	case strings.HasSuffix(domain, "-docker.pkg.dev"):
 		// <LOCATION>-docker.pkg.dev/<PROJECT>/<REPOSITORY>/<PACKAGE>
 		return artifactregistry.New(&artifactregistry.Config{Domain: domain}), nil


### PR DESCRIPTION
## Summary
- Add GitHub Container Registry (ghcr.io) support to docker-tags tool
- Implement anonymous token authentication for public repositories following Docker Registry v2 API

## Implementation Details

### Core Changes
1. **Created GHCR Registry Implementation** (`internal/registry/ghcr/registry.go`)
   - Implements `Registry` interface with `ListTags(name string) ([]string, error)` method
   - Uses anonymous token authentication via `https://ghcr.io/token?scope=repository:{name}:pull`
   - Custom HTTP client implementation (not using `dockerutil.Client` due to GHCR-specific requirements)
   - Returns tags in reverse order to match other registry patterns (most recent first)

2. **Updated Domain Detection** (`internal/registry/registry.go`)
   - Added import for `github.com/koki-develop/docker-tags/internal/registry/ghcr`
   - Added case `domain == "ghcr.io"` in registry selection switch statement

3. **Enhanced Error Handling**
   - Implemented `io.ReadAll(resp.Body)` pattern following `dockerutil.Client.do()` approach
   - Returns actual GHCR API error responses instead of generic messages
   - Users now see detailed errors like `{"errors":[{"code":"DENIED","message":"requested access to the resource is denied"}]}`

### Authentication Research & Implementation
- **Initial Challenge**: GHCR requires authentication even for public repositories
- **Authentication Flow**: 
  1. Anonymous token request to `https://ghcr.io/token?scope=repository:{name}:pull`
  2. Use returned Bearer token for `https://ghcr.io/v2/{name}/tags/list`
- **Key Finding**: No `service` parameter needed (unlike Docker Hub), only `scope` parameter required
- **Error Response Format**: GHCR returns structured JSON errors that provide actionable feedback

### Testing & Validation
- **Test Repository**: Used `ghcr.io/toddysm/python` (confirmed working public repository)
- **Output Formats**: Verified text, JSON, and YAML output work correctly
- **Flags**: Confirmed `--with-name` flag functions properly
- **Error Cases**: Tested with non-existent repositories to verify proper error handling
- **Quality Checks**: 
  - ✅ `golangci-lint run ./...` (0 issues)
  - ✅ `go test ./... -race -coverprofile=coverage.out -covermode=atomic` (all pass)

### Documentation Updates
1. **CLAUDE.md Enhancements**
   - Updated supported registries list and domain detection logic
   - Added comprehensive "Registry Implementation Guidelines" section
   - Documented authentication patterns for different registry types
   - Added conventional commit format requirements
   - Included error handling best practices

2. **README.md Updates**
   - Added GitHub Container Registry to supported registries list
   - Avoided promoting deprecated Google Container Registry

### Development Process
- **GitHub Issue**: Created detailed issue #81 with research findings and implementation plan
- **Branch Management**: Used `feature/add-ghcr-support` branch with conventional commits
- **Commit History**: 
  - `feat: add support for GitHub Container Registry (ghcr.io)` - Core implementation
  - `docs: update CLAUDE.md with GHCR support and registry guidelines` - Documentation
  - `docs: add GitHub Container Registry to README.md` - User documentation
- **Code Review**: Self-reviewed implementation and improved error handling based on existing patterns

## Architecture Decision: Custom Authentication vs dockerutil.Client

**Decision**: Implemented custom authentication rather than using existing `dockerutil.Client`

**Reasoning**:
- `dockerutil.Client.NewAuthRequest()` hardcodes `service=registry.docker.io` parameter
- GHCR token endpoint does not require/accept the `service` parameter
- Custom implementation provides cleaner separation and follows GHCR's exact API requirements
- Maintains consistency with other custom auth implementations (GCR uses custom Google Cloud auth)

## Test Plan
- [x] Test with public repository (`ghcr.io/toddysm/python`)
- [x] Verify all output formats (text, JSON, YAML)
- [x] Test `--with-name` flag functionality
- [x] Test error handling with non-existent repositories
- [x] Run linting with `golangci-lint run ./...` (0 issues)
- [x] Run tests with `go test ./... -race` (all pass)
- [x] Verify conventional commit format compliance
- [x] Update documentation (CLAUDE.md, README.md)

## Usage Examples
```bash
# Basic usage
docker-tags ghcr.io/username/repository

# JSON output
docker-tags ghcr.io/username/repository -o json

# With image name prefix
docker-tags ghcr.io/username/repository --with-name

# Docker CLI plugin mode
docker tags ghcr.io/username/repository
```

🤖 Generated with [Claude Code](https://claude.ai/code)